### PR TITLE
<textarea> now becomes one of literal HTML block tags

### DIFF
--- a/pycmark/blockparser/html_processors.py
+++ b/pycmark/blockparser/html_processors.py
@@ -47,11 +47,11 @@ class BaseHTMLBlockProcessor(PatternBlockProcessor):
         return True
 
 
-# 4.6 HTML blocks; <script>, <pre>, <script>
+# 4.6 HTML blocks; <script>, <pre>, <script>, <textarea>
 class ScriptHTMLBlockProcessor(BaseHTMLBlockProcessor):
     priority = 400
-    pattern = re.compile(r'^ {0,3}<(script|pre|style)( |>|$)', re.I)
-    closing_pattern = re.compile(r'</(script|pre|style)>', re.I)
+    pattern = re.compile(r'^ {0,3}<(script|pre|style|textarea)( |>|$)', re.I)
+    closing_pattern = re.compile(r'</(script|pre|style|textarea)>', re.I)
 
 
 # 4.6 HTML blocks; <!-- ... -->

--- a/tests/test_blockparser_html.py
+++ b/tests/test_blockparser_html.py
@@ -141,6 +141,18 @@ def test_example_138():
                                           [nodes.paragraph, "okay"])])
 
 
+def test_example_138_2():
+    text = ("""<textarea>\n"""
+            """\n"""
+            """*foo*\n"""
+            """\n"""
+            """_bar_\n"""
+            """\n"""
+            """</textarea>\n""")
+    result = publish(text)
+    assert_node(result, [nodes.document, nodes.raw])
+
+
 def test_example_141():
     text = ("""> <div>\n"""
             """> foo\n"""


### PR DESCRIPTION
refs: https://github.com/commonmark/commonmark-spec/commit/24b9d3835a31829771a69e0b1002128843d0e1cc