### PR TITLE
Rename CommonMarkParser to Parser

### DIFF
--- a/pycmark/__init__.py
+++ b/pycmark/__init__.py
@@ -10,8 +10,7 @@
 
 from typing import List, Type
 
-from docutils import nodes
-from docutils.parsers import Parser
+from docutils import nodes, parsers
 from docutils.transforms import Transform
 
 from pycmark.blockparser import BlockParser, BlockProcessor
@@ -75,7 +74,7 @@ from pycmark.transforms import (
 )
 
 
-class CommonMarkParser(Parser):
+class Parser(parsers.Parser):
     """CommonMark parser for docutils."""
 
     supported = ('markdown', 'commonmark', 'md')

--- a/pycmark/cli.py
+++ b/pycmark/cli.py
@@ -10,8 +10,8 @@
 
 from docutils.core import publish_cmdline
 
-from pycmark import CommonMarkParser
+from pycmark import Parser
 
 
 def md2html() -> None:
-    publish_cmdline(parser=CommonMarkParser(), writer_name='html5')
+    publish_cmdline(parser=Parser(), writer_name='html5')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,7 +9,7 @@
 from docutils.core import publish_doctree
 from docutils.readers.standalone import Reader
 
-from pycmark import CommonMarkParser
+from pycmark import Parser
 from pycmark.transforms import LinebreakFilter
 
 from sphinx import assert_node  # NOQA
@@ -20,7 +20,7 @@ class TestReader(Reader):
         return []  # skip all of transforms!
 
 
-class TestParser(CommonMarkParser):
+class TestParser(Parser):
     def get_transforms(self):
         transforms = super().get_transforms()
         transforms.remove(LinebreakFilter)


### PR DESCRIPTION
Docutils expects a parser class is named as "Parser" when it searches a
parse from 3rd party module.

This follows the expectation by renaming CommonMarkparser class to
"Parser".