### PR TITLE
Do not pass rawsource to nodes.Text

### DIFF
--- a/pycmark/transforms.py
+++ b/pycmark/transforms.py
@@ -209,7 +209,7 @@ class EmphasisConverter(Transform):
         markers = list(n for n in node.children if isinstance(n, addnodes.emphasis))
         for delim in markers:
             marker = str(delim)
-            delim.replace_self(Text(marker, marker))
+            delim.replace_self(Text(marker))
 
 
 class BracketConverter(Transform):
@@ -231,6 +231,6 @@ class TextNodeConnector(Transform):
                     text = node[pos] + node[pos + 1]  # type: ignore
                     node.remove(node[pos + 1])
                     node.remove(node[pos])
-                    node.insert(pos, Text(text, text))
+                    node.insert(pos, Text(text))
                 else:
                     pos += 1


### PR DESCRIPTION
The rawsource argument for nodes.Text was deprecated since
docutils-0.18.